### PR TITLE
Add persistent database and core models (Member, Activity, Signup)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -19,63 +19,34 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+
+# Persistent database setup
+from src.db import get_session, init_db
+from src.models import Member, Activity, Signup
+from sqlmodel import select
+
+# Initialize DB and seed sample activities if needed
+init_db()
+
+def seed_activities():
+    session = get_session()
+    if session.exec(select(Activity)).first() is None:
+        sample_activities = [
+            Activity(name="Chess Club", description="Learn strategies and compete in chess tournaments", schedule="Fridays, 3:30 PM - 5:00 PM", max_participants=12),
+            Activity(name="Programming Class", description="Learn programming fundamentals and build software projects", schedule="Tuesdays and Thursdays, 3:30 PM - 4:30 PM", max_participants=20),
+            Activity(name="Gym Class", description="Physical education and sports activities", schedule="Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM", max_participants=30),
+            Activity(name="Soccer Team", description="Join the school soccer team and compete in matches", schedule="Tuesdays and Thursdays, 4:00 PM - 5:30 PM", max_participants=22),
+            Activity(name="Basketball Team", description="Practice and play basketball with the school team", schedule="Wednesdays and Fridays, 3:30 PM - 5:00 PM", max_participants=15),
+            Activity(name="Art Club", description="Explore your creativity through painting and drawing", schedule="Thursdays, 3:30 PM - 5:00 PM", max_participants=15),
+            Activity(name="Drama Club", description="Act, direct, and produce plays and performances", schedule="Mondays and Wednesdays, 4:00 PM - 5:30 PM", max_participants=20),
+            Activity(name="Math Club", description="Solve challenging problems and participate in math competitions", schedule="Tuesdays, 3:30 PM - 4:30 PM", max_participants=10),
+            Activity(name="Debate Team", description="Develop public speaking and argumentation skills", schedule="Fridays, 4:00 PM - 5:30 PM", max_participants=12),
+        ]
+        session.add_all(sample_activities)
+        session.commit()
+    session.close()
+
+seed_activities()
 
 
 @app.get("/")
@@ -83,50 +54,72 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+
 @app.get("/activities")
 def get_activities():
-    return activities
+    session = get_session()
+    activities = session.exec(select(Activity)).all()
+    result = {}
+    for activity in activities:
+        participants = session.exec(select(Member.email).join(Signup, Signup.member_id == Member.id).where(Signup.activity_id == activity.id)).all()
+        result[activity.name] = {
+            "description": activity.description,
+            "schedule": activity.schedule,
+            "max_participants": activity.max_participants,
+            "participants": participants
+        }
+    session.close()
+    return result
+
 
 
 @app.post("/activities/{activity_name}/signup")
 def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    session = get_session()
+    activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+    if not activity:
+        session.close()
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    member = session.exec(select(Member).where(Member.email == email)).first()
+    if not member:
+        member = Member(name=email.split('@')[0].capitalize(), email=email)
+        session.add(member)
+        session.commit()
+        session.refresh(member)
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+    existing_signup = session.exec(select(Signup).where(Signup.activity_id == activity.id, Signup.member_id == member.id)).first()
+    if existing_signup:
+        session.close()
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Add student
-    activity["participants"].append(email)
+    signup = Signup(member_id=member.id, activity_id=activity.id)
+    session.add(signup)
+    session.commit()
+    session.close()
     return {"message": f"Signed up {email} for {activity_name}"}
+
 
 
 @app.delete("/activities/{activity_name}/unregister")
 def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+    session = get_session()
+    activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+    if not activity:
+        session.close()
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    member = session.exec(select(Member).where(Member.email == email)).first()
+    if not member:
+        session.close()
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Validate student is signed up
-    if email not in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
-        )
+    signup = session.exec(select(Signup).where(Signup.activity_id == activity.id, Signup.member_id == member.id)).first()
+    if not signup:
+        session.close()
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
 
-    # Remove student
-    activity["participants"].remove(email)
+    session.delete(signup)
+    session.commit()
+    session.close()
     return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,11 @@
+from sqlmodel import SQLModel, create_engine, Session
+
+DATABASE_URL = "sqlite:///./database.db"
+engine = create_engine(DATABASE_URL, echo=True)
+
+def get_session():
+    return Session(engine)
+
+def init_db():
+    import src.models  # Ensure models are imported
+    SQLModel.metadata.create_all(engine)

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,23 @@
+from typing import Optional
+from datetime import datetime
+from sqlmodel import SQLModel, Field
+
+class Member(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    email: str
+    grade: Optional[str]
+    is_active: bool = True
+
+class Activity(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    description: Optional[str]
+    schedule: Optional[str]
+    max_participants: Optional[int]
+
+class Signup(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    member_id: int
+    activity_id: int
+    signed_up_at: datetime = Field(default_factory=datetime.utcnow)


### PR DESCRIPTION
This PR implements persistent database support using SQLModel and adds core models for Member, Activity, and Signup. It refactors the API to use the database for all activity and signup operations, replacing the previous in-memory data approach.